### PR TITLE
refactor: Auth refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-.vscode/launch.json
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -1,49 +1,37 @@
-# tap-dynamodb
+# `tap-dynamodb`
 
-`tap-dynamodb` is a Singer tap for DynamoDB.
+DynamoDB tap class.
 
-Built with the [Meltano Tap SDK](https://sdk.meltano.com) for Singer Taps.
+Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 
-<!--
+## Capabilities
 
-Developer TODO: Update the below as needed to correctly describe the install procedure. For instance, if you do not have a PyPi repo, or if you want users to directly install from your git repo, you can modify this step as appropriate.
+* `catalog`
+* `state`
+* `discover`
+* `about`
+* `stream-maps`
+* `schema-flattening`
 
-## Installation
+## Settings
 
-Install from PyPi:
+| Setting              | Required | Default | Description |
+|:---------------------|:--------:|:-------:|:------------|
+| aws_access_key_id    | False    | None    | The access key for your AWS account. |
+| aws_secret_access_key| False    | None    | The secret key for your AWS account. |
+| aws_session_token    | False    | None    | The session key for your AWS account. This is only needed when you are using temporary credentials. |
+| aws_profile          | False    | None    | The AWS credentials profile name to use. The profile must be configured and accessible. |
+| aws_default_region   | False    | None    | The default AWS region name (e.g. us-east-1)  |
+| aws_endpoint_url     | False    | None    | The complete URL to use for the constructed client. |
+| aws_assume_role_arn  | False    | None    | The role ARN to assume. |
+| use_aws_env_vars     | False    |       0 | Whether to retrieve aws credentials from environment variables. |
+| tables               | False    | None    | An array of table names to extract from. |
+| stream_maps          | False    | None    | Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). |
+| stream_map_config    | False    | None    | User-defined config values to be used within map expressions. |
+| flattening_enabled   | False    | None    | 'True' to enable schema flattening and automatically expand nested properties. |
+| flattening_max_depth | False    | None    | The max depth to flatten schemas. |
 
-```bash
-pipx install tap-dynamodb
-```
-
-Install from GitHub:
-
-```bash
-pipx install git+https://github.com/ORG_NAME/tap-dynamodb.git@main
-```
-
--->
-
-## Configuration
-
-### Accepted Config Options
-
-<!--
-Developer TODO: Provide a list of config options accepted by the tap.
-
-This section can be created by copy-pasting the CLI output from:
-
-```
-tap-dynamodb --about --format=markdown
-```
--->
-
-A full list of supported settings and capabilities for this
-tap is available by running:
-
-```bash
-tap-dynamodb --about
-```
+A full list of supported settings and capabilities is available by running: `tap-dynamodb --about`
 
 ### Configure using environment variables
 
@@ -52,10 +40,6 @@ This Singer tap will automatically import any environment variables within the w
 environment variable is set either in the terminal context or in the `.env` file.
 
 ### Source Authentication and Authorization
-
-<!--
-Developer TODO: If your tap requires special access on the source system, or any special authentication requirements, provide those here.
--->
 
 ## Usage
 
@@ -107,12 +91,6 @@ poetry run tap-dynamodb --help
 
 _**Note:** This tap will work in any Singer environment and does not require Meltano.
 Examples here are for convenience and to streamline end-to-end orchestration scenarios._
-
-<!--
-Developer TODO:
-Your project comes with a custom `meltano.yml` project file already created. Open the `meltano.yml` and follow any "TODO" items listed in
-the file.
--->
 
 Next, install Meltano (if you haven't already) and any needed plugins:
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -15,15 +15,64 @@ plugins:
     - discover
     - about
     - stream-maps
-    config:
-      start_date: '2010-01-01T00:00:00Z'
+    - schema-flattening
     settings:
-    # TODO: To configure using Meltano, declare settings and their types here:
-    - name: username
-    - name: password
+    - name: aws_access_key_id
+      label: AWS Access Key ID
+      description: The access key for your AWS account.
       kind: password
-    - name: start_date
-      value: '2010-01-01T00:00:00Z'
+    - name: aws_secret_access_key
+      label: AWS Secret Access Key
+      description: The secret key for your AWS account.
+      kind: password
+    - name: aws_session_token
+      label: AWS Session Token
+      description: The session key for your AWS account. This is only needed when you
+        are using temporary credentials.
+      kind: password
+    - name: aws_profile
+      label: AWS Profile
+      description: The AWS credentials profile name to use. The profile must be configured
+        and accessible.
+      kind: string
+    - name: aws_default_region
+      label: AWS Default Region
+      description: 'The default AWS region name (e.g. us-east-1) '
+      kind: string
+    - name: aws_endpoint_url
+      label: AWS Endpoint URL
+      description: The complete URL to use for the constructed client.
+      kind: string
+    - name: aws_assume_role_arn
+      label: AWS Assume Role Arn
+      description: The role ARN to assume.
+      kind: string
+    - name: use_aws_env_vars
+      label: Use AWS Env Vars
+      description: Whether to retrieve aws credentials from environment variables.
+      kind: boolean
+    - name: tables
+      label: Tables
+      description: An array of table names to extract from.
+      kind: array
+    - name: stream_maps
+      label: Stream Maps
+      description: Config object for stream maps capability. For more information check
+        out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+      kind: object
+    - name: stream_map_config
+      label: Stream Map Config
+      description: User-defined config values to be used within map expressions.
+      kind: object
+    - name: flattening_enabled
+      label: Flattening Enabled
+      description: "'True' to enable schema flattening and automatically expand nested\
+        \ properties."
+      kind: boolean
+    - name: flattening_max_depth
+      label: Flattening Max Depth
+      description: The max depth to flatten schemas.
+      kind: integer
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/tap_dynamodb/aws_auth.py
+++ b/tap_dynamodb/aws_auth.py
@@ -27,7 +27,6 @@ class AWSAuth:
 
     def get_session(self):
         session = None
-        # TODO: require region
         if (
             self.aws_access_key_id
             and self.aws_secret_access_key

--- a/tap_dynamodb/aws_auth.py
+++ b/tap_dynamodb/aws_auth.py
@@ -32,6 +32,7 @@ class AWSAuth:
             self.aws_access_key_id
             and self.aws_secret_access_key
             and self.aws_session_token
+            and self.aws_default_region
         ):
             session = boto3.Session(
                 aws_access_key_id=self.aws_access_key_id,
@@ -39,7 +40,11 @@ class AWSAuth:
                 aws_session_token=self.aws_session_token,
                 region_name=self.aws_default_region,
             )
-        elif self.aws_access_key_id and self.aws_secret_access_key:
+        elif (
+            self.aws_access_key_id
+            and self.aws_secret_access_key
+            and self.aws_default_region
+        ):
             session = boto3.Session(
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,

--- a/tap_dynamodb/aws_auth.py
+++ b/tap_dynamodb/aws_auth.py
@@ -1,0 +1,95 @@
+import logging
+import os
+
+import boto3
+
+
+class AWSAuth:
+    def __init__(self, config):
+        # config for use environment variables
+        if config.get("use_aws_env_vars"):
+            self.aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
+            self.aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+            self.aws_session_token = os.environ.get("AWS_SESSION_TOKEN")
+            self.aws_profile = os.environ.get("AWS_PROFILE")
+            self.aws_default_region = os.environ.get("AWS_DEFAULT_REGION")
+        else:
+            self.aws_access_key_id = config.get("aws_access_key_id")
+            self.aws_secret_access_key = config.get("aws_secret_access_key")
+            self.aws_session_token = config.get("aws_session_token")
+            self.aws_profile = config.get("aws_profile")
+            self.aws_default_region = config.get("aws_default_region")
+
+        self.aws_endpoint_url = config.get("aws_endpoint_url")
+        # Should these be excluded and an empty boto call made, it then risks unknown auth config errors
+        # I sort of like the idea of forcing something to be set
+        # self.aws_config_file = config.get("aws_config_file") or os.environ.get("AWS_CONFIG_FILE")
+        # self.aws_shared_credentials_file = config.get("aws_shared_credentials_file") or os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+        self.aws_assume_role_arn = config.get("aws_assume_role_arn")
+
+        self.logger = logging.getLogger(__name__)
+
+    def get_session(self):
+        session = None
+        # TODO: require region
+        if (
+            self.aws_access_key_id
+            and self.aws_secret_access_key
+            and self.aws_session_token
+        ):
+            session = boto3.Session(
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                aws_session_token=self.aws_session_token,
+                region_name=self.aws_default_region,
+            )
+        elif self.aws_access_key_id and self.aws_secret_access_key:
+            session = boto3.Session(
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                region_name=self.aws_default_region,
+            )
+        elif self.aws_profile:
+            session = boto3.Session(profile_name=self.aws_profile)
+            self.logger.info("Using installed shared credentials file.")
+        else:
+            raise Exception("Explicit AWS auth not provided")
+            # self.logger.warning(
+            #     "Explicit AWS auth not provided, using implicit config file or shared credentials file."
+            # )
+            # session = boto3.Session()
+
+        if self.aws_assume_role_arn:
+            if not session:
+                raise Exception("Insufficient inputs for AWS Auth.")
+            session = self._assume_role(session, self.aws_assume_role_arn)
+        return session
+
+    def _factory(self, aws_obj, service_name):
+        if self.aws_endpoint_url:
+            return aws_obj(
+                service_name,
+                endpoint_url=self.aws_endpoint_url,
+            )
+        else:
+            return aws_obj(
+                service_name,
+            )
+
+    def get_resource(self, session, service_name):
+        return self._factory(session.resource, service_name)
+
+    def get_client(self, session, service_name):
+        return self._factory(session.client, service_name)
+
+    def _assume_role(self, session, role_arn):
+        # TODO: use for auto refresh https://github.com/benkehoe/aws-assume-role-lib
+        sts_client = self.get_client(session, "sts")
+        response = sts_client.assume_role(
+            RoleArn=role_arn, RoleSessionName="tap-dynamodb"
+        )
+        return boto3.Session(
+            aws_access_key_id=response["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+            aws_session_token=response["Credentials"]["SessionToken"],
+        )

--- a/tap_dynamodb/aws_auth.py
+++ b/tap_dynamodb/aws_auth.py
@@ -21,10 +21,6 @@ class AWSAuth:
             self.aws_default_region = config.get("aws_default_region")
 
         self.aws_endpoint_url = config.get("aws_endpoint_url")
-        # Should these be excluded and an empty boto call made, it then risks unknown auth config errors
-        # I sort of like the idea of forcing something to be set
-        # self.aws_config_file = config.get("aws_config_file") or os.environ.get("AWS_CONFIG_FILE")
-        # self.aws_shared_credentials_file = config.get("aws_shared_credentials_file") or os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
         self.aws_assume_role_arn = config.get("aws_assume_role_arn")
 
         self.logger = logging.getLogger(__name__)
@@ -54,10 +50,6 @@ class AWSAuth:
             self.logger.info("Using installed shared credentials file.")
         else:
             raise Exception("Explicit AWS auth not provided")
-            # self.logger.warning(
-            #     "Explicit AWS auth not provided, using implicit config file or shared credentials file."
-            # )
-            # session = boto3.Session()
 
         if self.aws_assume_role_arn:
             if not session:

--- a/tap_dynamodb/aws_base.py
+++ b/tap_dynamodb/aws_base.py
@@ -1,0 +1,32 @@
+import logging
+
+from tap_dynamodb.aws_auth import AWSAuth
+
+
+class AWSBase:
+    def __init__(self, config, service_name):
+        self._service_name = service_name
+        self._config = config
+        self._client = None
+        self._resource = None
+        self.logger = logging.getLogger(__name__)
+
+    @property
+    def client(self):
+        if self._client:
+            return self._client
+        else:
+            auth_obj = AWSAuth(self._config)
+            session = auth_obj.get_session()
+            self._client = auth_obj.get_resource(session, self._service_name)
+            return self._client
+
+    @property
+    def resource(self):
+        if self._resource:
+            return self._resource
+        else:
+            auth_obj = AWSAuth(self._config)
+            session = auth_obj.get_session()
+            self._resource = auth_obj.get_client(session, self._service_name)
+            return self._resource

--- a/tap_dynamodb/aws_base.py
+++ b/tap_dynamodb/aws_base.py
@@ -18,7 +18,7 @@ class AWSBase:
         else:
             auth_obj = AWSAuth(self._config)
             session = auth_obj.get_session()
-            self._client = auth_obj.get_resource(session, self._service_name)
+            self._client = auth_obj.get_client(session, self._service_name)
             return self._client
 
     @property
@@ -28,5 +28,5 @@ class AWSBase:
         else:
             auth_obj = AWSAuth(self._config)
             session = auth_obj.get_session()
-            self._resource = auth_obj.get_client(session, self._service_name)
+            self._resource = auth_obj.get_resource(session, self._service_name)
             return self._resource

--- a/tap_dynamodb/dynamo.py
+++ b/tap_dynamodb/dynamo.py
@@ -10,13 +10,11 @@ class DynamoDB(AWSBase):
     def __init__(self, config):
         super().__init__(config, "dynamodb")
 
-    def list_tables(self, filters=[]):
+    def list_tables(self, include=None):
         try:
             tables = []
             for table in self.resource.tables.all():
-                if filters and table.name in filters:
-                    tables.append(table.name)
-                else:
+                if include is None or table.name in include:
                     tables.append(table.name)
         except ClientError as err:
             self.logger.error(

--- a/tap_dynamodb/dynamo.py
+++ b/tap_dynamodb/dynamo.py
@@ -1,4 +1,3 @@
-import boto3
 import genson
 import orjson
 from botocore.exceptions import ClientError
@@ -63,11 +62,6 @@ class DynamoDB(AWSBase):
             )
             raise
 
-    def get_key_properties(self, table_name):
-        # TODO: use this for required
-        dynamo_schema = self.resource.Table(table_name).key_schema
-        return [key.get("AttributeName") for key in dynamo_schema]
-
     def get_table_json_schema(self, table_name: str, strategy: str = "infer"):
         sample_records = list(
             self.get_items_iter(
@@ -91,11 +85,6 @@ class DynamoDB(AWSBase):
         else:
             raise Exception(f"Strategy {strategy} not supported")
         return schema
-
-    @staticmethod
-    def deserialize_record(data):
-        deserializer = boto3.dynamodb.types.TypeDeserializer()
-        return {k: deserializer.deserialize(v) for k, v in data.items()}
 
     def recursively_drop_required(self, schema: dict) -> None:
         """Recursively drop the required property from a schema.

--- a/tap_dynamodb/dynamo.py
+++ b/tap_dynamodb/dynamo.py
@@ -1,57 +1,20 @@
-import logging
-import os
-
 import boto3
 import genson
 import orjson
 from botocore.exceptions import ClientError
 
+from tap_dynamodb.aws_base import AWSBase
 from tap_dynamodb.exception import EmptyTableException
 
 
-class DynamoDB:
-    def __init__(self):
-        self._client = None
-        self.logger = logging.getLogger(__name__)
-
-    def authenticate(self, config):
-        if self._client:
-            return
-
-        aws_access_key_id = config.get("aws_access_key_id") or os.environ.get(
-            "AWS_ACCESS_KEY_ID"
-        )
-        aws_secret_access_key = config.get("aws_secret_access_key") or os.environ.get(
-            "AWS_SECRET_ACCESS_KEY"
-        )
-        aws_session_token = config.get("aws_session_token") or os.environ.get(
-            "AWS_SESSION_TOKEN"
-        )
-        aws_profile = config.get("aws_profile") or os.environ.get("AWS_PROFILE")
-        aws_endpoint_url = config.get("aws_endpoint_url")
-        aws_region_name = config.get("aws_region_name")
-
-        # AWS credentials based authentication
-        if aws_access_key_id and aws_secret_access_key:
-            aws_session = boto3.session.Session(
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-                aws_session_token=aws_session_token,
-                region_name=aws_region_name,
-            )
-        # AWS Profile based authentication
-        else:
-            aws_session = boto3.session.Session(profile_name=aws_profile)
-        if aws_endpoint_url:
-            client = aws_session.resource("dynamodb", endpoint_url=aws_endpoint_url)
-        else:
-            client = aws_session.resource("dynamodb")
-        self._client = client
+class DynamoDB(AWSBase):
+    def __init__(self, config):
+        super().__init__(config, "dynamodb")
 
     def list_tables(self, filters=[]):
         try:
             tables = []
-            for table in self._client.tables.all():
+            for table in self.resource.tables.all():
                 if filters and table.name in filters:
                     tables.append(table.name)
                 else:
@@ -79,7 +42,7 @@ class DynamoDB:
     def get_items_iter(
         self, table_name: str, scan_kwargs: dict = {"ConsistentRead": True}
     ):
-        table = self._client.Table(table_name)
+        table = self.resource.Table(table_name)
         try:
             done = False
             start_key = None
@@ -102,7 +65,7 @@ class DynamoDB:
 
     def get_key_properties(self, table_name):
         # TODO: use this for required
-        dynamo_schema = self._client.Table(table_name).key_schema
+        dynamo_schema = self.resource.Table(table_name).key_schema
         return [key.get("AttributeName") for key in dynamo_schema]
 
     def get_table_json_schema(self, table_name: str, strategy: str = "infer"):

--- a/tap_dynamodb/tap.py
+++ b/tap_dynamodb/tap.py
@@ -57,6 +57,11 @@ class TapDynamoDB(Tap):
             description="The complete URL to use for the constructed client.",
         ),
         th.Property(
+            "aws_assume_role_arn",
+            th.StringType,
+            description="The role ARN to assume.",
+        ),
+        th.Property(
             "use_aws_env_vars",
             th.BooleanType,
             default=False,

--- a/tap_dynamodb/tap.py
+++ b/tap_dynamodb/tap.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-# TODO: Import your custom stream types here:
 from tap_dynamodb import streams
 from tap_dynamodb.dynamo import DynamoDB
 from tap_dynamodb.exception import EmptyTableException

--- a/tap_dynamodb/tap.py
+++ b/tap_dynamodb/tap.py
@@ -16,7 +16,6 @@ class TapDynamoDB(Tap):
 
     name = "tap-dynamodb"
 
-    # TODO: Update this section with the actual config values you expect:
     config_jsonschema = th.PropertiesList(
         th.Property(
             "aws_access_key_id",
@@ -48,14 +47,20 @@ class TapDynamoDB(Tap):
             ),
         ),
         th.Property(
+            "aws_default_region",
+            th.StringType,
+            description="The default AWS region name (e.g. us-east-1) ",
+        ),
+        th.Property(
             "aws_endpoint_url",
             th.StringType,
             description="The complete URL to use for the constructed client.",
         ),
         th.Property(
-            "aws_region_name",
-            th.StringType,
-            description="The AWS region name (e.g. us-east-1) ",
+            "use_aws_env_vars",
+            th.BooleanType,
+            default=False,
+            description="Whether to retrieve aws credentials from environment variables.",
         ),
         th.Property(
             "tables",
@@ -70,8 +75,7 @@ class TapDynamoDB(Tap):
         Returns:
             A list of discovered streams.
         """
-        obj = DynamoDB()
-        obj.authenticate(self.config)
+        obj = DynamoDB(self.config)
         discovered_streams = []
         for table_name in obj.list_tables(self.config.get("tables")):
             try:

--- a/tap_dynamodb/tap.py
+++ b/tap_dynamodb/tap.py
@@ -60,7 +60,9 @@ class TapDynamoDB(Tap):
             "use_aws_env_vars",
             th.BooleanType,
             default=False,
-            description="Whether to retrieve aws credentials from environment variables.",
+            description=(
+                "Whether to retrieve aws credentials from environment variables."
+            ),
         ),
         th.Property(
             "tables",

--- a/tests/test_aws_auth.py
+++ b/tests/test_aws_auth.py
@@ -1,0 +1,107 @@
+import pytest
+from contextlib import nullcontext as does_not_raise
+from unittest import mock
+from moto import mock_dynamodb, mock_sts
+from tap_dynamodb.aws_auth import AWSAuth
+import os
+from unittest.mock import patch
+import botocore
+
+@patch("tap_dynamodb.aws_auth.boto3.Session", return_value="mock_session")
+@mock_dynamodb
+def test_get_session_base(patch):
+    auth = AWSAuth(
+        {
+            "aws_access_key_id": "foo",
+            "aws_secret_access_key": "bar",
+            "aws_default_region": "baz",
+        }
+    )
+    session = auth.get_session()
+    patch.assert_called_with(
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+        region_name="baz",
+    )
+    assert session == "mock_session"
+
+@patch("tap_dynamodb.aws_auth.boto3.Session", return_value="mock_session")
+@mock_dynamodb
+def test_get_session_w_token(patch):
+    auth = AWSAuth(
+        {
+            "aws_access_key_id": "foo",
+            "aws_secret_access_key": "bar",
+            "aws_session_token": "abc",
+            "aws_default_region": "baz",
+        }
+    )
+    session = auth.get_session()
+    patch.assert_called_with(
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+        aws_session_token="abc",
+        region_name="baz",
+    )
+    assert session == "mock_session"
+
+
+@patch("tap_dynamodb.aws_auth.boto3.Session", return_value="mock_session")
+@mock_dynamodb
+def test_get_session_w_profile(patch):
+    auth = AWSAuth(
+        {
+            "aws_profile": "foo",
+        }
+    )
+    session = auth.get_session()
+    patch.assert_called_with(
+        profile_name="foo",
+    )
+    assert session == "mock_session"
+
+
+@mock_dynamodb
+def test_get_session_empty_fail():
+    with pytest.raises(Exception):
+        auth = AWSAuth({})
+        auth.get_session()
+
+
+@mock_dynamodb
+@mock_sts
+def test_get_session_assume_role():
+    auth = AWSAuth(
+        {
+            "aws_access_key_id": "foo",
+            "aws_secret_access_key": "bar",
+            "aws_default_region": "baz",
+            "aws_assume_role_arn": "arn:aws:iam::123456778910:role/my-role-name"
+        }
+    )
+    session = auth.get_session()
+
+
+@mock_dynamodb
+def test_get_client():
+    auth = AWSAuth(
+        {
+            "aws_access_key_id": "foo",
+            "aws_secret_access_key": "bar",
+            "aws_default_region": "baz",
+        }
+    )
+    session = auth.get_session()
+    client = auth.get_client(session, "dynamodb")
+
+@mock_dynamodb
+def test_get_resource():
+    auth = AWSAuth(
+        {
+            "aws_access_key_id": "foo",
+            "aws_secret_access_key": "bar",
+            "aws_default_region": "baz",
+        }
+    )
+    session = auth.get_session()
+    resource = auth.get_resource(session, "dynamodb")

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -3,6 +3,11 @@ from moto import mock_dynamodb
 
 from tap_dynamodb.dynamo import DynamoDB
 
+SAMPLE_CONFIG = {
+    "aws_access_key_id": "foo",
+    "aws_secret_access_key": "bar",
+    "aws_default_region": "baz"
+}
 
 def create_table(moto_conn, name):
     return moto_conn.create_table(
@@ -27,8 +32,8 @@ def test_list_tables():
         create_table(moto_conn, f"table_{num}")
     # END PREP
 
-    db_obj = DynamoDB()
-    db_obj._client = moto_conn
+    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj._resource = moto_conn
     tables = db_obj.list_tables()
     assert len(tables) == 105
     assert tables[0] == "table_1"
@@ -43,8 +48,8 @@ def test_get_items():
     table.put_item(Item={"year": 2023, "title": "foo", "info": {"plot": "bar"}})
     # END PREP
 
-    db_obj = DynamoDB()
-    db_obj._client = moto_conn
+    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj._resource = moto_conn
     records = list(db_obj.get_items_iter("table"))[0]
     assert len(records) == 1
     # Type coercion
@@ -64,8 +69,8 @@ def test_get_items_paginate():
         )
     # END PREP
 
-    db_obj = DynamoDB()
-    db_obj._client = moto_conn
+    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj._resource = moto_conn
     iterations = 0
     records = []
     for i in db_obj.get_items_iter("table", {"Limit": 1, "ConsistentRead": True}):
@@ -90,8 +95,8 @@ def test_get_table_json_schema():
         )
     # END PREP
 
-    db_obj = DynamoDB()
-    db_obj._client = moto_conn
+    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj._resource = moto_conn
     schema = db_obj.get_table_json_schema("table")
     assert schema == {
         "type": "object",
@@ -105,7 +110,7 @@ def test_get_table_json_schema():
 
 def test_coerce_types():
     import decimal
-    db_obj = DynamoDB()
+    db_obj = DynamoDB(SAMPLE_CONFIG)
     coerced = db_obj._coerce_types(
         {
             "foo": decimal.Decimal("1.23")

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -53,6 +53,8 @@ def test_list_tables_filtered():
     tables = db_obj.list_tables()
     assert len(tables) == 2
     assert tables == ["table_to_replicate", "table_to_skip"]
+    tables = db_obj.list_tables([])
+    assert len(tables) == 0
 
 @mock_dynamodb
 def test_get_items():

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -38,6 +38,21 @@ def test_list_tables():
     assert tables[0] == "table_1"
     assert tables[-1] == "table_105"
 
+@mock_dynamodb
+def test_list_tables_filtered():
+    # PREP
+    moto_conn = boto3.resource("dynamodb", region_name="us-west-2")
+    create_table(moto_conn, "table_to_replicate")
+    create_table(moto_conn, "table_to_skip")
+    # END PREP
+
+    db_obj = DynamoDB(SAMPLE_CONFIG)
+    tables = db_obj.list_tables(["table_to_replicate"])
+    assert len(tables) == 1
+    assert tables[0] == "table_to_replicate"
+    tables = db_obj.list_tables()
+    assert len(tables) == 2
+    assert tables == ["table_to_replicate", "table_to_skip"]
 
 @mock_dynamodb
 def test_get_items():

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -6,7 +6,7 @@ from tap_dynamodb.dynamo import DynamoDB
 SAMPLE_CONFIG = {
     "aws_access_key_id": "foo",
     "aws_secret_access_key": "bar",
-    "aws_default_region": "baz"
+    "aws_default_region": "us-west-2"
 }
 
 def create_table(moto_conn, name):
@@ -33,7 +33,6 @@ def test_list_tables():
     # END PREP
 
     db_obj = DynamoDB(SAMPLE_CONFIG)
-    db_obj._resource = moto_conn
     tables = db_obj.list_tables()
     assert len(tables) == 105
     assert tables[0] == "table_1"
@@ -49,7 +48,6 @@ def test_get_items():
     # END PREP
 
     db_obj = DynamoDB(SAMPLE_CONFIG)
-    db_obj._resource = moto_conn
     records = list(db_obj.get_items_iter("table"))[0]
     assert len(records) == 1
     # Type coercion
@@ -70,7 +68,6 @@ def test_get_items_paginate():
     # END PREP
 
     db_obj = DynamoDB(SAMPLE_CONFIG)
-    db_obj._resource = moto_conn
     iterations = 0
     records = []
     for i in db_obj.get_items_iter("table", {"Limit": 1, "ConsistentRead": True}):
@@ -96,7 +93,6 @@ def test_get_table_json_schema():
     # END PREP
 
     db_obj = DynamoDB(SAMPLE_CONFIG)
-    db_obj._resource = moto_conn
     schema = db_obj.get_table_json_schema("table")
     assert schema == {
         "type": "object",

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -114,3 +114,4 @@ def test_coerce_types():
     assert coerced == {
         "foo": "1.23"
     }
+


### PR DESCRIPTION
This is a first iteration at making the auth and aws base classes more portable and well tested, potentially allowing them to be moved to the SDK or at least directly copied to other taps when needed because this is the second time I've built this:

- Pulls the auth logic out into a standalone class
- Pulls the base AWS interface with auth and caching client/resource out to base class that gets inherited by the dynmodb specific class in this tap 
- Lots more tests around the auth steps

Opinionated decisions I made (can be changed):
- I want to be more explicit about auth parameters. There are lots of taps that accept AWS creds in different ways, some explicit some implicit from env vars or installed files. I'd prefer to to make these all explicit so in this case ENV vars arent used unless a `use_aws_env_vars` config is set, avoiding confusing behavior where a mix of explicit and implicit inputs are provided. I've been in the case where boto finds local credentials that I'm not intending to use and it causes weird and potentially bad side affects.
- The order is:
  - access key/secret/region
  - access key/secret/region + session token
  - profile name
  - raise error for now but would like to accept a flag to allow `use_implicit_credentials` where we dont verify anything and just let boto do its thing
- Like previously mentioned if `use_aws_env_vars` is set then credentials are pulled from the env and not from the config keys. My opinion is that we should force one or the other and not a mix.
- If `aws_assume_role_arn` is provided then the session created gets passed to the assume role method that creates a new one with the assumed role

Misc Stuff:
- refresh readme
- refresh tap config options
- refresh meltano.yml sample
- remove TODOs