### PR TITLE
refactor: Connector pattern refactor

### DIFF
--- a/tap_dynamodb/connectors/aws_boto_connector.py
+++ b/tap_dynamodb/connectors/aws_boto_connector.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Union
 
 from singer_sdk import typing as th  # JSON schema typing helpers
 
@@ -7,7 +8,8 @@ try:
     import boto3
 except ImportError:
     raise Exception(
-        "boto3 is required for this authenticator. Please install it with `poetry add boto3`."
+        "boto3 is required for this authenticator. "
+        "Please install it with `poetry add boto3`."
     )
 
 AWS_AUTH_CONFIG = th.PropertiesList(
@@ -145,8 +147,12 @@ class AWSBotoConnector:
 
     def get_session(self) -> boto3.session:
         """Return the boto3 session.
+
         Returns:
             boto3.session: The boto3 session.
+
+        Raises:
+            Exception: If no credentials are provided.
         """
         session = None
         if (
@@ -183,7 +189,9 @@ class AWSBotoConnector:
             session = self._assume_role(session, self.aws_assume_role_arn)
         return session
 
-    def _factory(self, aws_obj: object, service_name: str) -> object:
+    def _factory(
+        self, aws_obj, service_name: str
+    ) -> Union[boto3.resource, boto3.client]:
         if self.aws_endpoint_url:
             return aws_obj(
                 service_name,
@@ -194,10 +202,12 @@ class AWSBotoConnector:
                 service_name,
             )
 
-    def get_resource(
-        self, session: boto3.session.Session, service_name: str
-    ) -> boto3.resource:
+    def get_resource(self, session: boto3.session, service_name: str) -> boto3.resource:
         """Return the boto3 resource for the service.
+
+        Args:
+            session (boto3.session.Session): The boto3 session.
+            service_name (str): The name of the AWS service.
 
         Returns:
             boto3.resource: The boto3 resource for the service.
@@ -208,6 +218,10 @@ class AWSBotoConnector:
         self, session: boto3.session.Session, service_name: str
     ) -> boto3.client:
         """Return the boto3 client for the service.
+
+        Args:
+            session (boto3.session.Session): The boto3 session.
+            service_name (str): The name of the AWS service.
 
         Returns:
             boto3.client: The boto3 client for the service.

--- a/tap_dynamodb/connectors/aws_boto_connector.py
+++ b/tap_dynamodb/connectors/aws_boto_connector.py
@@ -1,3 +1,4 @@
+import abc
 import logging
 import os
 from typing import Union
@@ -66,7 +67,7 @@ AWS_AUTH_CONFIG = th.PropertiesList(
 ).to_dict()
 
 
-class AWSBotoConnector:
+class AWSBotoConnector(metaclass=abc.ABCMeta):
     def __init__(
         self,
         config: dict,

--- a/tap_dynamodb/connectors/aws_boto_connector.py
+++ b/tap_dynamodb/connectors/aws_boto_connector.py
@@ -1,4 +1,3 @@
-import abc
 import logging
 import os
 from typing import Union
@@ -67,7 +66,7 @@ AWS_AUTH_CONFIG = th.PropertiesList(
 ).to_dict()
 
 
-class AWSBotoConnector(metaclass=abc.ABCMeta):
+class AWSBotoConnector:
     def __init__(
         self,
         config: dict,

--- a/tap_dynamodb/dynamodb_connector.py
+++ b/tap_dynamodb/dynamodb_connector.py
@@ -1,5 +1,3 @@
-from typing import Any, Mapping
-
 import genson
 import orjson
 from botocore.exceptions import ClientError

--- a/tap_dynamodb/dynamodb_connector.py
+++ b/tap_dynamodb/dynamodb_connector.py
@@ -14,14 +14,11 @@ class DynamoDbConnector(AWSBotoConnector):
         config: dict,
     ) -> None:
         """Initialize the connector.
-        
+
         Args:
             config: The connector configuration.
         """
-        super().__init__(
-            config,
-            "dynamodb"
-        )
+        super().__init__(config, "dynamodb")
 
     @staticmethod
     def _coerce_types(record):
@@ -62,7 +59,6 @@ class DynamoDbConnector(AWSBotoConnector):
             raise
         else:
             return tables
-
 
     def get_items_iter(
         self, table_name: str, scan_kwargs: dict = {"ConsistentRead": True}
@@ -116,4 +112,3 @@ class DynamoDbConnector(AWSBotoConnector):
     def get_table_key_properties(self, table_name):
         key_schema = self.resource.Table(table_name).key_schema
         return [key.get("AttributeName") for key in key_schema]
-

--- a/tap_dynamodb/dynamodb_connector.py
+++ b/tap_dynamodb/dynamodb_connector.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 import genson
 import orjson
 from botocore.exceptions import ClientError
@@ -85,7 +87,7 @@ class DynamoDbConnector(AWSBotoConnector):
             )
             raise
 
-    def get_table_json_schema(self, table_name: str, strategy: str = "infer"):
+    def get_table_json_schema(self, table_name: str, strategy: str = "infer") -> dict:
         sample_records = list(
             self.get_items_iter(
                 table_name, scan_kwargs={"Limit": 100, "ConsistentRead": True}

--- a/tap_dynamodb/streams.py
+++ b/tap_dynamodb/streams.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Union
 
 from singer_sdk.plugin_base import PluginBase as TapBaseClass
 from singer_sdk.streams import Stream
@@ -28,8 +28,8 @@ class TableStream(Stream):
             dynamodb_conn: The DynamoDbConnector object.
         """
         self._dynamodb_conn: DynamoDbConnector = dynamodb_conn
-        self._table_name = name
-        self._schema = None
+        self._table_name: str = name
+        self._schema: dict = {}
         super().__init__(
             tap=tap,
             schema=self.schema,

--- a/tap_dynamodb/streams.py
+++ b/tap_dynamodb/streams.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Union
+from typing import Iterable
 
 from singer_sdk.plugin_base import PluginBase as TapBaseClass
 from singer_sdk.streams import Stream

--- a/tap_dynamodb/streams.py
+++ b/tap_dynamodb/streams.py
@@ -4,35 +4,41 @@ from __future__ import annotations
 
 from typing import Iterable
 
+
+from singer_sdk.plugin_base import PluginBase as TapBaseClass
 from singer_sdk.streams import Stream
 
-from tap_dynamodb.dynamo import DynamoDB
+from tap_dynamodb.dynamodb_connector import DynamoDbConnector
 
 
 class TableStream(Stream):
     """Stream class for TableStream streams."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        tap: TapBaseClass,
+        name: str,
+        dynamodb_conn: DynamoDbConnector,
+    ):
         """
         Initialize a new TableStream object.
 
         Args:
-            *args: Positional arguments.
-            **kwargs: Keyword arguments.
-                table_name (str): Name of the DynamoDB table to stream.
-                dynamodb_obj (DynamoDB): Instance of the DynamoDB client.
-
+            tap: The parent tap object.
+            name: The name of the stream.
+            dynamodb_conn: The DynamoDbConnector object.
         """
-        self.table_name = kwargs.get("name")
-        self.dynamodb_obj: DynamoDB = kwargs.pop("dynamodb_obj")
+        self._dynamodb_conn: DynamoDbConnector = dynamodb_conn
+        self._table_name = name
         self._schema = None
-        super().__init__(*args, **kwargs)
-
-    def get_jsonschema_type(self):
-        return "string"
+        super().__init__(
+            tap=tap,
+            schema=self.schema,
+            name=name,
+        )
 
     def get_records(self, context: dict | None) -> Iterable[dict]:
-        for batch in self.dynamodb_obj.get_items_iter(self.table_name):
+        for batch in self._dynamodb_conn.get_items_iter(self._table_name):
             for record in batch:
                 yield record
 
@@ -46,8 +52,8 @@ class TableStream(Stream):
         """
         # TODO: SDC columns
         if not self._schema:
-            self._schema = self.dynamodb_obj.get_table_json_schema(self.table_name)
-            self.primary_keys = self.dynamodb_obj.get_table_key_properties(
-                self.table_name
+            self._schema = self._dynamodb_conn.get_table_json_schema(self._table_name)
+            self.primary_keys = self._dynamodb_conn.get_table_key_properties(
+                self._table_name
             )
         return self._schema

--- a/tap_dynamodb/streams.py
+++ b/tap_dynamodb/streams.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Iterable
 
-
 from singer_sdk.plugin_base import PluginBase as TapBaseClass
 from singer_sdk.streams import Stream
 

--- a/tap_dynamodb/tap.py
+++ b/tap_dynamodb/tap.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
+from singer_sdk.plugin_base import PluginBase
 
 from tap_dynamodb import streams
-from tap_dynamodb.dynamo import DynamoDB
+from tap_dynamodb.connectors.aws_boto_connector import AWS_AUTH_CONFIG
+from tap_dynamodb.dynamodb_connector import DynamoDbConnector
 from tap_dynamodb.exception import EmptyTableException
 
 
@@ -16,58 +18,6 @@ class TapDynamoDB(Tap):
     name = "tap-dynamodb"
 
     config_jsonschema = th.PropertiesList(
-        th.Property(
-            "aws_access_key_id",
-            th.StringType,
-            secret=True,
-            description="The access key for your AWS account.",
-        ),
-        th.Property(
-            "aws_secret_access_key",
-            th.StringType,
-            secret=True,
-            description="The secret key for your AWS account.",
-        ),
-        th.Property(
-            "aws_session_token",
-            th.StringType,
-            secret=True,
-            description=(
-                "The session key for your AWS account. This is only needed when"
-                " you are using temporary credentials."
-            ),
-        ),
-        th.Property(
-            "aws_profile",
-            th.StringType,
-            description=(
-                "The AWS credentials profile name to use. The profile must be "
-                "configured and accessible."
-            ),
-        ),
-        th.Property(
-            "aws_default_region",
-            th.StringType,
-            description="The default AWS region name (e.g. us-east-1) ",
-        ),
-        th.Property(
-            "aws_endpoint_url",
-            th.StringType,
-            description="The complete URL to use for the constructed client.",
-        ),
-        th.Property(
-            "aws_assume_role_arn",
-            th.StringType,
-            description="The role ARN to assume.",
-        ),
-        th.Property(
-            "use_aws_env_vars",
-            th.BooleanType,
-            default=False,
-            description=(
-                "Whether to retrieve aws credentials from environment variables."
-            ),
-        ),
         th.Property(
             "tables",
             th.ArrayType(th.StringType),
@@ -81,19 +31,32 @@ class TapDynamoDB(Tap):
         Returns:
             A list of discovered streams.
         """
-        obj = DynamoDB(self.config)
+        dynamodb_conn = DynamoDbConnector(
+            self.config,
+        )
         discovered_streams = []
-        for table_name in self.config.get("tables") or obj.list_tables():
+        for table_name in self.config.get("tables") or dynamodb_conn.list_tables():
             try:
                 stream = streams.TableStream(
                     tap=self,
                     name=table_name,
-                    dynamodb_obj=obj,
+                    dynamodb_conn=dynamodb_conn,
                 )
                 discovered_streams.append(stream)
             except EmptyTableException:
                 self.logger.warning(f"Skipping '{table_name}'. No records found.")
         return discovered_streams
+
+    @classmethod
+    def append_builtin_config(cls: type[PluginBase], config_jsonschema: dict) -> None:
+        def _merge_missing(source_jsonschema: dict, target_jsonschema: dict) -> None:
+            # Append any missing properties in the target with those from source.
+            for k, v in source_jsonschema["properties"].items():
+                if k not in target_jsonschema["properties"]:
+                    target_jsonschema["properties"][k] = v
+
+        _merge_missing(AWS_AUTH_CONFIG, config_jsonschema)
+        super().append_builtin_config(config_jsonschema)
 
 
 if __name__ == "__main__":

--- a/tap_dynamodb/tap.py
+++ b/tap_dynamodb/tap.py
@@ -32,7 +32,7 @@ class TapDynamoDB(Tap):
             A list of discovered streams.
         """
         dynamodb_conn = DynamoDbConnector(
-            self.config,
+            dict(self.config),  # type: ignore
         )
         discovered_streams = []
         for table_name in self.config.get("tables") or dynamodb_conn.list_tables():
@@ -56,7 +56,7 @@ class TapDynamoDB(Tap):
                     target_jsonschema["properties"][k] = v
 
         _merge_missing(AWS_AUTH_CONFIG, config_jsonschema)
-        super().append_builtin_config(config_jsonschema)
+        super(TapDynamoDB, cls).append_builtin_config(config_jsonschema)  # type: ignore
 
 
 if __name__ == "__main__":

--- a/tests/test_boto_connector.py
+++ b/tests/test_boto_connector.py
@@ -29,7 +29,10 @@ def test_get_session_base(patch):
     assert session == "mock_session"
 
 
-@patch("tap_dynamodb.connectors.aws_boto_connector.boto3.Session", return_value="mock_session")
+@patch(
+    "tap_dynamodb.connectors.aws_boto_connector.boto3.Session",
+    return_value="mock_session",
+)
 @mock_dynamodb
 def test_get_session_w_token(patch):
     auth = AWSBotoConnector(
@@ -51,7 +54,10 @@ def test_get_session_w_token(patch):
     assert session == "mock_session"
 
 
-@patch("tap_dynamodb.connectors.aws_boto_connector.boto3.Session", return_value="mock_session")
+@patch(
+    "tap_dynamodb.connectors.aws_boto_connector.boto3.Session",
+    return_value="mock_session",
+)
 @mock_dynamodb
 def test_get_session_w_profile(patch):
     auth = AWSBotoConnector(

--- a/tests/test_boto_connector.py
+++ b/tests/test_boto_connector.py
@@ -3,16 +3,16 @@ from unittest.mock import patch
 import pytest
 from moto import mock_dynamodb, mock_sts
 
-from tap_dynamodb.aws_authenticators import AWSBotoAuthenticator
+from tap_dynamodb.connectors.aws_boto_connector import AWSBotoConnector
 
 
 @patch(
-    "tap_dynamodb.aws_authenticators.boto3.Session",
+    "tap_dynamodb.connectors.aws_boto_connector.boto3.Session",
     return_value="mock_session",
 )
 @mock_dynamodb
 def test_get_session_base(patch):
-    auth = AWSBotoAuthenticator(
+    auth = AWSBotoConnector(
         {
             "aws_access_key_id": "foo",
             "aws_secret_access_key": "bar",
@@ -29,10 +29,10 @@ def test_get_session_base(patch):
     assert session == "mock_session"
 
 
-@patch("tap_dynamodb.aws_authenticators.boto3.Session", return_value="mock_session")
+@patch("tap_dynamodb.connectors.aws_boto_connector.boto3.Session", return_value="mock_session")
 @mock_dynamodb
 def test_get_session_w_token(patch):
-    auth = AWSBotoAuthenticator(
+    auth = AWSBotoConnector(
         {
             "aws_access_key_id": "foo",
             "aws_secret_access_key": "bar",
@@ -51,10 +51,10 @@ def test_get_session_w_token(patch):
     assert session == "mock_session"
 
 
-@patch("tap_dynamodb.aws_authenticators.boto3.Session", return_value="mock_session")
+@patch("tap_dynamodb.connectors.aws_boto_connector.boto3.Session", return_value="mock_session")
 @mock_dynamodb
 def test_get_session_w_profile(patch):
-    auth = AWSBotoAuthenticator(
+    auth = AWSBotoConnector(
         {
             "aws_profile": "foo",
         },
@@ -70,14 +70,14 @@ def test_get_session_w_profile(patch):
 @mock_dynamodb
 def test_get_session_empty_fail():
     with pytest.raises(Exception):
-        auth = AWSBotoAuthenticator({})
+        auth = AWSBotoConnector({})
         auth.get_session()
 
 
 @mock_dynamodb
 @mock_sts
 def test_get_session_assume_role():
-    auth = AWSBotoAuthenticator(
+    auth = AWSBotoConnector(
         {
             "aws_access_key_id": "foo",
             "aws_secret_access_key": "bar",
@@ -91,7 +91,7 @@ def test_get_session_assume_role():
 
 @mock_dynamodb
 def test_get_client():
-    auth = AWSBotoAuthenticator(
+    auth = AWSBotoConnector(
         {
             "aws_access_key_id": "foo",
             "aws_secret_access_key": "bar",
@@ -105,7 +105,7 @@ def test_get_client():
 
 @mock_dynamodb
 def test_get_resource():
-    auth = AWSBotoAuthenticator(
+    auth = AWSBotoConnector(
         {
             "aws_access_key_id": "foo",
             "aws_secret_access_key": "bar",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,23 +1,11 @@
-"""Tests standard tap features using the built-in SDK tests library."""
+# """Tests standard tap features using the built-in SDK tests library."""
 
-import datetime
-import json
-import os
+# import json
 
-from moto import mock_dynamodb
-from singer_sdk.testing import get_tap_test_class
+# from singer_sdk.testing import get_tap_test_class
 
-from tap_dynamodb.tap import TapDynamoDB
+# from tap_dynamodb.tap import TapDynamoDB
 
-SAMPLE_CONFIG = {
-    # "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
-    # TODO: Initialize minimal tap config
-}
+# SAMPLE_CONFIG = json.load(open(".secrets/config.json"))
 
-SAMPLE_CONFIG = json.load(open(".secrets/config.json"))
-
-
-# Run standard built-in tap tests from the SDK:
-# TODO: this doesnt work yet
-# with mock_dynamodb():
-TestTapDynamoDB = get_tap_test_class(tap_class=TapDynamoDB, config=SAMPLE_CONFIG)
+# TestTapDynamoDB = get_tap_test_class(tap_class=TapDynamoDB, config=SAMPLE_CONFIG)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,24 +1,27 @@
-# """Tests standard tap features using the built-in SDK tests library."""
+"""Tests standard tap features using the built-in SDK tests library."""
 
-# import datetime
-# import os
+import datetime
+import os
+import json
+from singer_sdk.testing import get_tap_test_class
 
-# from singer_sdk.testing import get_tap_test_class
-
-# from tap_dynamodb.tap import TapDynamoDB
-# from moto import mock_dynamodb
-
-
-# SAMPLE_CONFIG = {
-#     # "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
-#     # TODO: Initialize minimal tap config
-# }
+from tap_dynamodb.tap import TapDynamoDB
+from moto import mock_dynamodb
 
 
-# # Run standard built-in tap tests from the SDK:
-# # TODO: this doesnt work yet
+SAMPLE_CONFIG = {
+    # "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+    # TODO: Initialize minimal tap config
+}
+    
+SAMPLE_CONFIG = json.load(open(".secrets/config.json"))
+
+
+
+# Run standard built-in tap tests from the SDK:
+# TODO: this doesnt work yet
 # with mock_dynamodb():
-#     TestTapDynamoDB = get_tap_test_class(
-#         tap_class=TapDynamoDB,
-#         config={"aws_profile": "foo"}
-#     )
+TestTapDynamoDB = get_tap_test_class(
+    tap_class=TapDynamoDB,
+    config=SAMPLE_CONFIG
+)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,27 +1,23 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
 import datetime
-import os
 import json
+import os
+
+from moto import mock_dynamodb
 from singer_sdk.testing import get_tap_test_class
 
 from tap_dynamodb.tap import TapDynamoDB
-from moto import mock_dynamodb
-
 
 SAMPLE_CONFIG = {
     # "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
     # TODO: Initialize minimal tap config
 }
-    
-SAMPLE_CONFIG = json.load(open(".secrets/config.json"))
 
+SAMPLE_CONFIG = json.load(open(".secrets/config.json"))
 
 
 # Run standard built-in tap tests from the SDK:
 # TODO: this doesnt work yet
 # with mock_dynamodb():
-TestTapDynamoDB = get_tap_test_class(
-    tap_class=TapDynamoDB,
-    config=SAMPLE_CONFIG
-)
+TestTapDynamoDB = get_tap_test_class(tap_class=TapDynamoDB, config=SAMPLE_CONFIG)

--- a/tests/test_dynamodb_connector.py
+++ b/tests/test_dynamodb_connector.py
@@ -1,7 +1,7 @@
 import boto3
 from moto import mock_dynamodb
 
-from tap_dynamodb.dynamo import DynamoDB
+from tap_dynamodb.dynamodb_connector import DynamoDbConnector
 
 SAMPLE_CONFIG = {
     "aws_access_key_id": "foo",
@@ -33,7 +33,7 @@ def test_list_tables():
         create_table(moto_conn, f"table_{num}")
     # END PREP
 
-    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj = DynamoDbConnector(SAMPLE_CONFIG)
     tables = db_obj.list_tables()
     assert len(tables) == 105
     assert tables[0] == "table_1"
@@ -48,7 +48,7 @@ def test_list_tables_filtered():
     create_table(moto_conn, "table_to_skip")
     # END PREP
 
-    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj = DynamoDbConnector(SAMPLE_CONFIG)
     tables = db_obj.list_tables(["table_to_replicate"])
     assert len(tables) == 1
     assert tables[0] == "table_to_replicate"
@@ -67,7 +67,7 @@ def test_get_items():
     table.put_item(Item={"year": 2023, "title": "foo", "info": {"plot": "bar"}})
     # END PREP
 
-    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj = DynamoDbConnector(SAMPLE_CONFIG)
     records = list(db_obj.get_items_iter("table"))[0]
     assert len(records) == 1
     # Type coercion
@@ -87,7 +87,7 @@ def test_get_items_paginate():
         )
     # END PREP
 
-    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj = DynamoDbConnector(SAMPLE_CONFIG)
     iterations = 0
     records = []
     for i in db_obj.get_items_iter("table", {"Limit": 1, "ConsistentRead": True}):
@@ -112,7 +112,7 @@ def test_get_table_json_schema():
         )
     # END PREP
 
-    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj = DynamoDbConnector(SAMPLE_CONFIG)
     schema = db_obj.get_table_json_schema("table")
     assert schema == {
         "type": "object",
@@ -135,13 +135,13 @@ def test_get_table_key_properties():
         )
     # END PREP
 
-    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj = DynamoDbConnector(SAMPLE_CONFIG)
     assert ["year", "title"] == db_obj.get_table_key_properties("table")
 
 
 def test_coerce_types():
     import decimal
 
-    db_obj = DynamoDB(SAMPLE_CONFIG)
+    db_obj = DynamoDbConnector(SAMPLE_CONFIG)
     coerced = db_obj._coerce_types({"foo": decimal.Decimal("1.23")})
     assert coerced == {"foo": "1.23"}


### PR DESCRIPTION
Related to https://github.com/meltano/sdk/issues/1493 and discussions [in slack](https://meltano.slack.com/archives/C03569WJXBL/p1681491308035779)

1. Refactors to fit the connector abstraction from the SDK better
2. The `AWSBotoConnector` class should be decoupled enough to pull out into the SDK
3. I took the approach of making a base connector for boto that developers can inherit to implement their resource specific logic like dynamo's list table/get items/etc.
4. I also pulled the settings json out of my tap and into the connector class module and implemented `append_builtin_config` to merge those settings with my dynamodb specific ones. This is similar to how stream maps configs are injected.

Related to 4 I'm not sure if theres a better way to inject those config settings because right now each developer would need to copy that code snippet into their tap. I was thinking this could be something the cookiecutter does but it would require introducing a new question like "Connector? [AWSBotoConnector, Other]".